### PR TITLE
Limit add 30s to 99:99, display times > 99:59 as 99:seconds

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -10,7 +10,13 @@ export function formatDigits(digits) {
 }
 
 export function formatTimer(timer) {
-  const minutes = pad(Math.floor(timer / 60));
-  const seconds = pad(timer % 60);
-  return `${minutes}:${seconds}`;
+  let minutes, seconds;
+  if (timer < 6000) { // <= 99:59
+    minutes = Math.floor(timer / 60);
+    seconds = timer % 60;
+  } else { // limit minutes to two digits
+    minutes = 99;
+    seconds = timer - minutes * 60;
+  }
+  return `${pad(minutes)}:${pad(seconds)}`;
 }

--- a/src/machine.js
+++ b/src/machine.js
@@ -103,7 +103,6 @@ export default Machine(
 
           ADD_THIRTY_SECS: {
             actions: ['add30SecondsToTimer'],
-            // TODO: add a guard so that it can't go over 99:99
           },
 
           TICK: [
@@ -206,6 +205,7 @@ export default Machine(
       add30SecondsToTimer: assign({
         timer: (context) => {
           if (context.timer === null) return 30;
+          if (context.timer > 6009) return 6039; // limit to 99:99
           return context.timer + 30;
         },
       }),


### PR DESCRIPTION
Resolves #3.
Also, displays times from 99:60 through 99:99 by increasing seconds instead of overflowing minutes to a third digit.