### PR TITLE
Add 'settingTimer' state which displays time instead of digits

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -13,10 +13,9 @@ export function formatTimer(timer) {
   let minutes, seconds;
   if (timer < 6000) { // <= 99:59
     minutes = Math.floor(timer / 60);
-    seconds = timer % 60;
   } else { // limit minutes to two digits
     minutes = 99;
-    seconds = timer - minutes * 60;
   }
+  seconds = timer - minutes * 60;
   return `${pad(minutes)}:${pad(seconds)}`;
 }

--- a/src/machine.js
+++ b/src/machine.js
@@ -74,7 +74,8 @@ export default Machine(
           ADD_THIRTY_SECS: [
             {
               cond: 'hasDigits',
-              actions: ['add30SecondsToDigits'],
+              actions: ['add30SecondsToDigits', 'setTimer'],
+              target: 'settingTimer',
             },
             {
               actions: ['add30SecondsToDigits', 'setTimer'],
@@ -82,6 +83,30 @@ export default Machine(
             },
           ],
         },
+      },
+
+      settingTimer: {
+        on: {
+          START: {
+            cond: 'hasDigits',
+            target: 'heating',
+          },
+          
+          STOP: {
+            actions: ['beep'],
+            target: 'idle',
+          },
+
+          ADD_THIRTY_SECS: {
+            actions: ['add30SecondsToTimer'],
+          },
+
+          DOOR_OPEN: {},
+
+          '*': {
+            target: 'idle',
+          },
+        }
       },
 
       heating: {

--- a/src/machine.js
+++ b/src/machine.js
@@ -74,7 +74,7 @@ export default Machine(
           ADD_THIRTY_SECS: [
             {
               cond: 'hasDigits',
-              actions: ['add30SecondsToDigits', 'setTimer'],
+              actions: ['setTimer', 'add30SecondsToTimer'],
               target: 'settingTimer',
             },
             {


### PR DESCRIPTION
Resolves #4 

Pressing ADD_THIRTY_SECS after entering time in digit form now transitions to the 'settingTimer' state, which displays time instead of digits.  In this state, pressing a digit (or stop) returns to the idle state.

Note: because 'idle' resets digits and timer on entry, the first digit input (which causes the state to change to idle) is effectively discarded.  If you're okay with it, we could move those actions to the beginning of each transition to idle and thus capture the first digit.

I also realized there was a redundant line in helpers.js from my last PR, so I cleaned that up.